### PR TITLE
Allow checking of sites that are only available securely

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = async (req, res) => {
   } else if (url.startsWith('https://')) {
     url = url.substr(8);
   }
-  let json = req.url.indexOf('?json') !== -1;
+  let json = req.url.endsWith('?json');
   assert(url !== '', 400, 'URL must be defined. Usage: https://up.now.sh/google.com');
   let statusCode;
   let message;

--- a/index.js
+++ b/index.js
@@ -2,13 +2,21 @@ const {send} = require('micro');
 const fetch = require('node-fetch');
 const assert = require('http-assert');
 
+const protocols = {
+  HTTP: 'http://',
+  HTTPS: 'https://'
+};
+
 module.exports = async (req, res) => {
   let url = req.url.substr(1).split('?')[0];
+  let requestScheme;
   if (url === 'favicon.ico') return;
-  if (url.startsWith('http://')) {
+  if (url.startsWith(protocols.HTTP)) {
     url = url.substr(7);
-  } else if (url.startsWith('https://')) {
+    requestScheme = protocols.HTTP;
+  } else if (url.startsWith(protocols.HTTPS)) {
     url = url.substr(8);
+    requestScheme = protocols.HTTPS;
   }
   let json = req.url.endsWith('?json');
   assert(url !== '', 400, 'URL must be defined. Usage: https://up.now.sh/google.com');
@@ -16,7 +24,7 @@ module.exports = async (req, res) => {
   let message;
   res.setHeader('Content-Type', 'application/json');
   try {
-    await fetch(`http://${url}`, {
+    await fetch(`${requestScheme}${url}`, {
       timeout: 5000
     });
     statusCode = 200;

--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ const assert = require('http-assert');
 module.exports = async (req, res) => {
   let url = req.url.substr(1).split('?')[0];
   if (url === 'favicon.ico') return;
-  if (url.indexOf('http://') !== -1) {
+  if (url.startsWith('http://')) {
     url = url.substr(7);
-  } else if (url.indexOf('https://') !== -1) {
+  } else if (url.startsWith('https://')) {
     url = url.substr(8);
   }
   let json = req.url.indexOf('?json') !== -1;

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,8 @@ You can override the default (plaintext) by appending `?json` to the end of the 
 GET https://up.now.sh/google.com?json
 HTTP/1.1 200 OK
 
-{"url":"google.com","status":"Up"}```
+{"url":"google.com","status":"Up"}
+```
 
 # Contributing
 Clone the repo, `yarn install`, `yarn run dev`, change what you'd like, and make a pull request ✌️


### PR DESCRIPTION
I often struggle with <https://migs.mastercard.com.au/ma/> because it goes down frequently and is only available over `https` (and doesn't redirect from `http`).

This PR maintains the scheme from the `path` url instead of defaulting to `fetch`ing over `http`, and thus allows the user to check a site like the one above.

It also include a minor fix for the README formatting and some code refactoring (_death to_ `indexOf` 🔥)

Nice work! 🎉 